### PR TITLE
Do not add a session ID for all pages: cache friendly

### DIFF
--- a/custom-contact-forms-front.php
+++ b/custom-contact-forms-front.php
@@ -13,7 +13,6 @@ if (!class_exists('CustomContactFormsFront')) {
 		var $current_thank_you_message;
 
 		function frontInit() {
-			ccf_utils::startSession();
 			$this->processForms();
 		}
 		
@@ -196,6 +195,7 @@ if (!class_exists('CustomContactFormsFront')) {
 		}
 		
 		function getFormCode($form, $is_widget_form = false) {
+			ccf_utils::startSession();
 			if (empty($form)) return '';
 			$admin_options = parent::getAdminOptions();
 			$form_key = time();


### PR DESCRIPTION
As described at http://wordpress.org/support/topic/ccf-not-cache-friendly:

The implementation of CCF forces caching to be bypassed even on pages WITHOUT forms.
THE PROBLEM:

The function ccf_utils::startSession() creates a PHP session and sends back a cookie to the browser. This is needed for things like CAPTCHA and other features.

Because of the cookie for the PHP session, headers are sent back to the browser and the caching servers to prevent caching of the page.

Because ccf_utils::startSession() is in frontInit, a session is created on EVERY PAGE. However, it ISN'T needed when there is no form on the page.

Making the changes above means that a session is only initiated if/when there's a form on the page.

Hope that helps others trying to make their site as speedy as possible
