### PR TITLE
Add access control over wp-admin ccf access

### DIFF
--- a/custom-contact-forms-admin.php
+++ b/custom-contact-forms-admin.php
@@ -2227,6 +2227,28 @@ if (!class_exists('CustomContactFormsAdmin')) {
 						<?php _e("Default subject to be included in all form emails.", 'custom-contact-forms'); ?>
 					  </li>
 					  <li>
+					  	<label for="admin_panel_access">
+					  		<?php _e("Admin Panel Access:", 'custom-contact-forms'); ?>
+					  	</label>
+					  	<select name="settings[admin_panel_access]">
+					  		<option value="admin" <?php if ($admin_options['admin_panel_access'] == "admin") echo 'selected="selected"'; ?>>
+					  			<?php _e("Administrator", 'custom-contact-forms'); ?>
+					  		</option>
+					  		<option value="editor" <?php if ($admin_options['admin_panel_access'] == "editor") echo 'selected="selected"'; ?>>
+					  			<?php _e("Editor", 'custom-contact-forms'); ?>
+					  		</option>
+					  		<option value="author" <?php if ($admin_options['admin_panel_access'] == "author") echo 'selected="selected"'; ?>>
+					  			<?php _e("Author", 'custom-contact-forms'); ?>
+					  		</option>
+					  		<option value="contributor" <?php if ($admin_options['admin_panel_access'] == "contributor") echo 'selected="selected"'; ?>>
+					  			<?php _e("Contributor", 'custom-contact-forms'); ?>
+					  		</option>
+				  		</select>
+				  	  </li>
+  					  <li class="descrip">
+						<?php _e("Change this to the desired level that you would like to be given access to Custom Contact Forms in the Wordpress admin panel (this page).", 'custom-contact-forms'); ?>
+					  </li>
+					  <li>
 						<label for="enable_dashboard_widget">
 						<?php _e("Enable Dashboard Widget:", 'custom-contact-forms'); ?>
 						</label>

--- a/custom-contact-forms.php
+++ b/custom-contact-forms.php
@@ -103,10 +103,21 @@ if (!is_admin()) { /* is front */
 			global $custom_contact_admin;
 			if (!isset($custom_contact_admin)) return;
 			if (function_exists('add_menu_page')) {
-				add_menu_page(__('Custom Contact Forms', 'custom-contact-forms'), __('Custom Contact Forms', 'custom-contact-forms'), 'manage_options', 'custom-contact-forms', array(&$custom_contact_admin, 'printAdminPage'));
-				add_submenu_page('custom-contact-forms', __('Custom Contact Forms', 'custom-contact-forms'), __('Custom Contact Forms', 'custom-contact-forms'), 'manage_options', 'custom-contact-forms', array(&$custom_contact_admin, 'printAdminPage'));
-				add_submenu_page('custom-contact-forms', __('Saved Form Submissions', 'custom-contact-forms'), __('Saved Form Submissions', 'custom-contact-forms'), 'manage_options', 'ccf-saved-form-submissions', array(&$custom_contact_admin, 'printFormSubmissionsPage'));
-				add_submenu_page('custom-contact-forms', __('General Settings', 'custom-contact-forms'), __('General Settings', 'custom-contact-forms'), 'manage_options', 'ccf-settings', array(&$custom_contact_admin, 'printSettingsPage'));
+				$ccfAccessRole = 'manage_options';
+				$admin_options = $custom_contact_admin->getAdminOptions();
+				if (!empty($admin_options['admin_panel_access'])) {
+					if ($admin_options['admin_panel_access'] == 'editor') {
+						$ccfAccessRole = 'edit_pages';
+					} elseif ($admin_options['admin_panel_access'] == 'author') {
+						$ccfAccessRole = 'publish_posts';
+					} elseif ($admin_options['admin_panel_access'] == 'contributor') {
+						$ccfAccessRole = 'edit_posts';
+					}
+				}
+				add_menu_page(__('Custom Contact Forms', 'custom-contact-forms'), __('Custom Contact Forms', 'custom-contact-forms'), $ccfAccessRole, 'custom-contact-forms', array(&$custom_contact_admin, 'printAdminPage'));
+				add_submenu_page('custom-contact-forms', __('Custom Contact Forms', 'custom-contact-forms'), __('Custom Contact Forms', 'custom-contact-forms'), $ccfAccessRole, 'custom-contact-forms', array(&$custom_contact_admin, 'printAdminPage'));
+				add_submenu_page('custom-contact-forms', __('Saved Form Submissions', 'custom-contact-forms'), __('Saved Form Submissions', 'custom-contact-forms'), $ccfAccessRole, 'ccf-saved-form-submissions', array(&$custom_contact_admin, 'printFormSubmissionsPage'));
+				add_submenu_page('custom-contact-forms', __('General Settings', 'custom-contact-forms'), __('General Settings', 'custom-contact-forms'), $ccfAccessRole, 'ccf-settings', array(&$custom_contact_admin, 'printSettingsPage'));
 			}
 		}
 	}


### PR DESCRIPTION
Allows an admin to define who can use ccf's settings/admin area in the
wp-admin panel.