### PR TITLE
Properly test if full WP-API exists

### DIFF
--- a/classes/class-ccf-custom-contact-forms.php
+++ b/classes/class-ccf-custom-contact-forms.php
@@ -129,7 +129,7 @@ class CCF_Custom_Contact_Forms {
 			}
 		}
 
-		if ( class_exists( 'create_initial_rest_routes' ) ) {
+		if ( function_exists( 'create_initial_rest_routes' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Hey there.  When WP-API plugin is already installed and activated, activating Custom Contact Forms errors out because it checks for the existence of a `create_initial_rest_routes` class which returns `false`.  

This pull request changes the check from `class_exists` to `function_exists`.