### PR TITLE
Reset field renderer instance after form render

### DIFF
--- a/classes/class-ccf-field-renderer.php
+++ b/classes/class-ccf-field-renderer.php
@@ -1172,6 +1172,14 @@ endif; ?>
 
 		return $field_html;
 	}
+	
+	/**
+	 * Resets the instance defaults
+	 */
+	public function reset() {
+		$this->section_open = false;
+	}
+	
 	/**
 	 * Return singleton instance of class
 	 *

--- a/classes/class-ccf-form-renderer.php
+++ b/classes/class-ccf-form-renderer.php
@@ -281,6 +281,8 @@ class CCF_Form_Renderer {
 		}
 
 		$form_html = ob_get_clean();
+		
+		CCF_Field_Renderer::factory()->reset();
 
 		return $form_html;
 	}


### PR DESCRIPTION
**Issue**

1. Create two forms on a page
2. The first form must have a section
3. The second form must not have a section
4. View the page, the second form will add a closing div just before the submit button, breaking the functionality

**Solution**

Add a reset function to the ```CCF_Field_Renderer``` class, which resets any defaults that are set from the previous instance.

**Considerations**

This is just a quick workaround, ```CCF_Field_Renderer``` being a singleton is an issue here, I get why it is but as you may be rendering multiple forms on the same page, you don't want the same instance to be carried over to all forms.