### PR TITLE
Adding placeholder for file extensions

### DIFF
--- a/classes/class-ccf-form-manager.php
+++ b/classes/class-ccf-form-manager.php
@@ -621,7 +621,7 @@ class CCF_Form_Manager {
 					</div>
 					<div>
 						<label for="ccf-field-file-extensions"><?php esc_html_e( 'Allowed File Extensions (comma separate):', 'custom-contact-forms' ); ?></label>
-						<input id="ccf-field-file-extensions" class="field-file-extensions" type="text" value="{{ field.fileExtensions }}">
+						<input id="ccf-field-file-extensions" class="field-file-extensions" type="text" value="{{ field.fileExtensions }}" placeholder="jpg,gif,png">
 						<span class="explain"><?php _e( 'If left blank, will default to all extensions registered by WordPress. If you use a file extension or mime type not <a href="http://codex.wordpress.org/Function_Reference/get_allowed_mime_types">whitelisted by WordPress</a>, you will need to filter and manually whitelist the new extension.', 'custom-contact-forms' ); ?></span>
 					</div>
 					<div>


### PR DESCRIPTION
It doesn't explicitly mention anywhere what format to add file extensions in, I personally added `.pdf` instead of `pdf` which adds `..pdf` to the `accept` attribute on the file input.

Was playing around with changing the regex but this makes more sense, just to inform the user before they make the mistake.