### PR TITLE
Adding filter for redirect url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 tests/codeception/_output/*
 tests/codeception/acceptance/AcceptanceTester.php
 vendor
+.DS_Store

--- a/classes/class-ccf-form-handler.php
+++ b/classes/class-ccf-form-handler.php
@@ -1032,7 +1032,7 @@ class CCF_Form_Handler {
 			}
 
 			if ( 'redirect' === $output['action_type'] ) {
-				$output['completion_redirect_url'] = apply_filters( 'ccf_form_completion_redirect_url', get_post_meta( $form_id, 'ccf_form_completion_redirect_url', true ), $_REQUEST );
+				$output['completion_redirect_url'] = apply_filters( 'ccf_form_completion_redirect_url', get_post_meta( $form_id, 'ccf_form_completion_redirect_url', true ) );
 			} else {
 				$output['completion_message'] = get_post_meta( $form_id, 'ccf_form_completion_message', true );
 

--- a/classes/class-ccf-form-handler.php
+++ b/classes/class-ccf-form-handler.php
@@ -1032,7 +1032,7 @@ class CCF_Form_Handler {
 			}
 
 			if ( 'redirect' === $output['action_type'] ) {
-				$output['completion_redirect_url'] = apply_filters( 'ccf_form_completion_redirect_url', get_post_meta( $form_id, 'ccf_form_completion_redirect_url', true ) );
+				$output['completion_redirect_url'] = apply_filters( 'ccf_form_completion_redirect_url', get_post_meta( $form_id, 'ccf_form_completion_redirect_url', true ), $form_id );
 			} else {
 				$output['completion_message'] = get_post_meta( $form_id, 'ccf_form_completion_message', true );
 

--- a/classes/class-ccf-form-handler.php
+++ b/classes/class-ccf-form-handler.php
@@ -1032,7 +1032,7 @@ class CCF_Form_Handler {
 			}
 
 			if ( 'redirect' === $output['action_type'] ) {
-				$output['completion_redirect_url'] = get_post_meta( $form_id, 'ccf_form_completion_redirect_url', true );
+				$output['completion_redirect_url'] = apply_filters( 'ccf_form_completion_redirect_url', get_post_meta( $form_id, 'ccf_form_completion_redirect_url', true ), $_REQUEST );
 			} else {
 				$output['completion_message'] = get_post_meta( $form_id, 'ccf_form_completion_message', true );
 


### PR DESCRIPTION
**Issue**

As far as I can see there is no way to modify the redirect URL. See the scenario described in #247 

**Solution**

Adds a filter to `ccf_form_completion_redirect_url`, aptly named `ccf_form_completion_redirect_url`. The first parameter is the the redirect value, the second parameter is the `$_REQUEST` data.

**Usage**

```php
function modify_redirect($url) {
    $remove = '/?';
    $strippedURL = str_replace($remove, '', strstr($_REQUEST['form_page'], $remove));
    parse_str($strippedURL, $parsed);
    if(isset($parsed['j'])) {
        $url .= '?j=' . $parsed['j'];
    }
    return $url;
}
add_filter('ccf_form_completion_redirect_url', 'modify_redirect', 10);
```

**Considerations**

As far as I saw, none of the filters are documented, so that's probably something that needs doing.

P.S also added `.DS_Store` to `.gitignore`