### PR TITLE
removed MIME-Version, it gets duplicated

### DIFF
--- a/classes/class-ccf-form-handler.php
+++ b/classes/class-ccf-form-handler.php
@@ -966,7 +966,7 @@ class CCF_Form_Handler {
 							}
 						}
 
-						$headers = array( 'MIME-Version: 1.0', 'Content-type: text/html; charset=utf-8' );
+						$headers = array('Content-type: text/html; charset=utf-8' );
 						$name = null;
 						$email = null;
 


### PR DESCRIPTION
it seems that Wordpress phpmailer already inserts MIME-Version in mail headers.
When "custom contact form" plugin sends the notification email, it adds the MIME-Version header and it gets duplicated.
Servers may not accept the mail, resulting the error: 554 Transaction failed: Duplicate header 'MIME-Version'.